### PR TITLE
Genre登録機能実装

### DIFF
--- a/app/assets/stylesheets/genres.scss
+++ b/app/assets/stylesheets/genres.scss
@@ -1,0 +1,53 @@
+.genre_registration_space {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 85vh;
+  background-color: #795548;
+}
+
+.genre_registration_box {
+  width: 30vw;
+  height: 45vh;
+  text-align: center;
+  border: 4px solid #5D4037;
+}
+
+.genre_registration_name_top {
+  color: white;
+  font-size: 2rem;
+  background-color: #5D4037;
+}
+
+.genre_name_registration_box {
+  margin-top: 10vh;
+}
+
+.genre_input_size {
+  width: 20vw;
+  height: 10vh;
+  font-size: 1.7rem;
+}
+
+.genre_name_registration_submit {
+  margin-top: 5vh;
+}
+
+.genre_name_submit {
+  width: 10vw;
+  height: 5vh;
+}
+
+.notification {
+  position: absolute;
+  top: 7%;
+  left: 50%;
+  -ms-transform: translate(-50%,-50%);
+  -webkit-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  margin:0;
+  padding:0;
+  color: red;
+  font-size: 2rem;
+}
+

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -1,0 +1,21 @@
+class GenresController < ApplicationController
+  def new
+    @genre = Genre.new
+  end
+
+  def create
+    @genre = Genre.new(genre_params)
+    if @genre.save
+      redirect_to root_path
+    else
+      flash.now[:error_genre] = "ジャンルの内容は必須です。"
+      render :new
+    end
+  end
+
+  private
+  def genre_params
+    params.require(:genre).permit(:genre_name).merge(user_id: current_user.id)
+  end
+
+end

--- a/app/helpers/genres_helper.rb
+++ b/app/helpers/genres_helper.rb
@@ -1,0 +1,2 @@
+module GenresHelper
+end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,6 @@
+class Genre < ApplicationRecord
+  validates :genre_name, presence: true
+  belongs_to :user
+  has_many :books
+  has_many :read_book_logs
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   mount_uploader :image, ImageUploader
+
+  belongs_to :genre
+  has_many :books
+  has_many :read_book_logs
 end

--- a/app/views/genres/new.html.erb
+++ b/app/views/genres/new.html.erb
@@ -1,0 +1,17 @@
+<div class="headder">
+  <%= render "books/headder" %>
+</div>
+
+<div class="genre_registration_space">
+  <div class="genre_registration_box">
+    <h2 class="genre_registration_name_top">本のジャンル登録</h2>
+    <%= form_with(model: @genre, local: true) do |form| %>
+      <div class="genre_name_registration_box">
+        <%= form.text_field :genre_name , class: "genre_input_size", placeholder: "本のジャンル名" %>
+      </div>
+      <div class="genre_name_registration_submit">
+        <%= form.submit  "登録" , class: "genre_name_submit"%>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,11 @@
   </head>
 
   <body>
+    <div class="notification">
+      <% flash.each do |message_type, message| %>
+        <%= message %>
+      <% end %>
+    </div>
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "toppages#index"
-
-  
+  resources :genres , only: [:new, :create]
   resources :books , only: [:index, :new, :create, :edit, :update, :destroy]
 end

--- a/db/migrate/20210910125957_create_genres.rb
+++ b/db/migrate/20210910125957_create_genres.rb
@@ -1,0 +1,9 @@
+class CreateGenres < ActiveRecord::Migration[6.0]
+  def change
+    create_table :genres, id: :bigint do |t|
+      t.string :genre_name,                 null: :false
+      t.integer :user_id,                   null: :false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_09_125942) do
+ActiveRecord::Schema.define(version: 2021_09_10_125957) do
+
+  create_table "genres", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "genre_name"
+    t.integer "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/test/controllers/genres_controller_test.rb
+++ b/test/controllers/genres_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GenresControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/genres.yml
+++ b/test/fixtures/genres.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/genre_test.rb
+++ b/test/models/genre_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GenreTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
Genre登録機能の実装
# Why
ジャンル別で子どもの興味を測るため、本の登録をする際関連づけて登録する必要がある。